### PR TITLE
Fix typos in documentation

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,12 +1,12 @@
 Package: HAZDist
 Type: Package
-Title: Distance calculation funciton using Norman Abrahamson's HAZ fortran code
+Title: Distance calculation function using Norman Abrahamson's HAZ fortran code
 Version: 0.1.7
 Author: Person Lin
 Maintainer: Person Lin <personlin@gmail.com>
 Depends: R (>= 3.1.0)
 SystemRequirements: GNU make
-Description: This package provide a set of R warp function to call distance calcualtion function
+Description: This package provide a set of R wrap function to call distance calculation function
     from Norman Abrahamson's HAZ fortran code for using in GMPE.
 License: GPL (>= 3)
 Encoding: UTF-8

--- a/R/HAZDist.r
+++ b/R/HAZDist.r
@@ -1,4 +1,4 @@
-#' HAZDist: Distance calculation funciton using Norman Abrahamson's HAZ fortran code.
+#' HAZDist: Distance calculation function using Norman Abrahamson's HAZ fortran code.
 #'
 #' The HAZDist package provides distance calculation functions:
 #' SetFltBottom, ConvertCoordinates2, calcfltgrid, CalcDist, getfaultcoord, getfaultdist

--- a/man/HAZDist.Rd
+++ b/man/HAZDist.Rd
@@ -5,7 +5,7 @@
 \alias{HAZDist}
 \alias{.onUnload}
 \alias{HAZDist-package}
-\title{HAZDist: Distance calculation funciton using Norman Abrahamson's HAZ fortran code.}
+\title{HAZDist: Distance calculation function using Norman Abrahamson's HAZ fortran code.}
 \usage{
 .onUnload(libpath)
 }


### PR DESCRIPTION
## Summary
- fix typos in DESCRIPTION Title and Description lines
- correct spelling in package docs
- update Rd documentation

## Testing
- `R CMD build .` *(fails: R not installed)*
- `R CMD check HAZDist_0.1.7.tar.gz` *(fails: R not installed)*

------
https://chatgpt.com/codex/tasks/task_e_684a56a963d48333af797431abbb5515