### PR TITLE
Fix CalcDist documentation typos

### DIFF
--- a/R/CalcDist.r
+++ b/R/CalcDist.r
@@ -1,6 +1,6 @@
 #' Distance calculation function from Norman Abrahamson's HAZ program.
 #'
-#' \code{CalcDist} returns the computes the distance parameters for the GMPEs.
+#' \code{CalcDist} computes the distance parameters for the GMPEs.
 #'                 (e.g. Rjb, Rrup, ZTOR, Rx, Ry, Ry0)
 #'
 #' @param faultW Fault width
@@ -25,7 +25,7 @@
 #' @param ft.fltGrid_Rjb Fault grid JB distance.
 #' @param ystep ystep in fault input file.
 #'
-#' @return A list will be return, includingHWFlag, hypoDepth, ZTOR, RupWidth, RupLen, seismoDepth,
+#' @return A list will be returned, includingHWFlag, hypoDepth, ZTOR, RupWidth, RupLen, seismoDepth,
 #' distJB, distRup, distSeism, distepi, disthypo, Rx, Ry, Ry0.
 #'
 #' @examples

--- a/man/CalcDist.Rd
+++ b/man/CalcDist.Rd
@@ -54,11 +54,11 @@ CalcDist(faultW, faultLen, seismoDepth = 0, ft.fltGrid_x, ft.fltGrid_y,
 \item{ystep}{ystep in fault input file.}
 }
 \value{
-A list will be return, includingHWFlag, hypoDepth, ZTOR, RupWidth, RupLen, seismoDepth,
+A list will be returned, includingHWFlag, hypoDepth, ZTOR, RupWidth, RupLen, seismoDepth,
 distJB, distRup, distSeism, distepi, disthypo, Rx, Ry, Ry0.
 }
 \description{
-\code{CalcDist} returns the computes the distance parameters for the GMPEs.
+\code{CalcDist} computes the distance parameters for the GMPEs.
                 (e.g. Rjb, Rrup, ZTOR, Rx, Ry, Ry0)
 }
 \examples{


### PR DESCRIPTION
## Summary
- fix wording in `CalcDist` documentation

## Testing
- `R --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684a56dda0f8833386aa4c5310315dad