### PR TITLE
Fix Rrup variable typo

### DIFF
--- a/src/HazDist.f
+++ b/src/HazDist.f
@@ -155,7 +155,7 @@ C         for this rupture area since it is needed for the NGA directivity model
           do j=iLocX,n2
             do i=iLocY,n1
               if (distRup .gt. fltgrid_Rrup(i,j)) then
-                distRup = fltgrid_rRup(i,j)
+                distRup = fltgrid_Rrup(i,j)
                 icellRupstrike = j
                 icellRupdip = i
               endif


### PR DESCRIPTION
## Summary
- correct variable name in Fortran distance loop

## Testing
- `R CMD INSTALL .` *(fails: R not found)*

------
https://chatgpt.com/codex/tasks/task_e_684a56e3313c83339ae04e8f662fa60d